### PR TITLE
docs: remove Mem0 driver version from overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 | 中间件 | 分布式任务 | ElasticJob            | 3.1.0     | 505.2.0  | 506.0.0    | [使用指南](Elasticjob/3.1.0/README.md)                  |
 | AI | 向量检索 | LlamaIndex-GaussDB    | 0.1.0 | 505.2.0  |            | [使用指南](./LlamaIndex-GaussDB/0.1.0/README.md) |
 | AI | 向量检索 | LangChain-GaussDB     | 0.1.0 | 505.2.0  |            | [使用指南](./LangChain-GaussDB/0.1.0/README.md) |
-| AI | Agent 记忆 | Mem0-GaussDB     | 2.0.4 | 505.2.0  | psycopg2 2.9.x | [使用指南](./Mem0-GaussDB/2.0.4/README.md) |
+| AI | Agent 记忆 | Mem0-GaussDB     | 2.0.4 | 505.2.0  | - | [使用指南](./Mem0-GaussDB/2.0.4/README.md) |
 
 * 可以通过 `select version()` 查询GaussDB版本信息。
 * 可以参考 [gaussdb-drivers](https://github.com/HuaweiCloudDeveloper/gaussdb-drivers) 进一步了解驱动信息。

--- a/README_en.md
+++ b/README_en.md
@@ -41,7 +41,7 @@ This project aggregates comprehensive information about the GaussDB open-source 
 | Middleware | Distributed Tasks | ElasticJob          | 3.1.0            | 505.2.0  | 506.0.0    | [Usage Guide](Elasticjob/3.1.0/README_en.md)        |
 | AI | Vector Search | LlamaIndex-GaussDB    | 0.1.0            | 505.2.0  |            | [Usage Guide](./LlamaIndex-GaussDB/0.1.0/README_en.md) |
 | AI | Vector Search | LangChain-GaussDB     | 0.1.0            | 505.2.0  |            | [Usage Guide](./LangChain-GaussDB/0.1.0/README_en.md) |
-| AI | Agent Memory | Mem0-GaussDB     | 2.0.4            | 505.2.0  | psycopg2 2.9.x | [Usage Guide](./Mem0-GaussDB/2.0.4/README_en.md) |
+| AI | Agent Memory | Mem0-GaussDB     | 2.0.4            | 505.2.0  | - | [Usage Guide](./Mem0-GaussDB/2.0.4/README_en.md) |
 
 * Use `select version()` to check your GaussDB version.  
 * Refer to [gaussdb-drivers](https://github.com/HuaweiCloudDeveloper/gaussdb-drivers) for driver details.  


### PR DESCRIPTION
## Summary
- Remove the fixed \psycopg2 2.9.x\ driver version from the Mem0-GaussDB row in the Chinese and English overview tables.
- Keep the usage guide links unchanged.

## Testing
- Documentation-only change; not run.