### PR TITLE
docs: update AI components for GaussDB 507.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@
 | 中间件 | 分布式任务 | ElasticJob            | 3.1.0     | 505.2.0  | 506.0.0    | [使用指南](Elasticjob/3.1.0/README.md)                  |
 | AI | 向量检索 | LlamaIndex-GaussDB    | 0.1.0 | 505.2.0  |            | [使用指南](./LlamaIndex-GaussDB/0.1.0/README.md) |
 | AI | 向量检索 | LangChain-GaussDB     | 0.1.0 | 505.2.0  |            | [使用指南](./LangChain-GaussDB/0.1.0/README.md) |
-| AI | Agent 记忆 | Mem0-GaussDB     | 2.0.4 | 505.2.0  | - | [使用指南](./Mem0-GaussDB/2.0.4/README.md) |
-| AI | 向量检索 | RAGFlow-GaussDB    | 0.26.4 | 505.2.0  | - | [使用指南](./RAGFlow-GaussDB/0.26.4/README.md) |
-| AI | 向量检索 | LangGraph-GaussDB     | 0.1.0 | 505.2.0  |            | [使用指南](./LangGraph-GaussDB/0.1.0/README.md) |
+| AI | Agent 记忆 | Mem0-GaussDB     | 2.0.4 | 507.0.0  | - | [使用指南](./Mem0-GaussDB/2.0.4/README.md) |
+| AI | 向量检索 | RAGFlow-GaussDB    | 0.26.4 | 507.0.0  | - | [使用指南](./RAGFlow-GaussDB/0.26.4/README.md) |
+| AI | 向量检索 | LangGraph-GaussDB     | 0.1.0 | 507.0.0  |            | [使用指南](./LangGraph-GaussDB/0.1.0/README.md) |
 
 * 可以通过 `select version()` 查询GaussDB版本信息。
 * 可以参考 [gaussdb-drivers](https://github.com/HuaweiCloudDeveloper/gaussdb-drivers) 进一步了解驱动信息。

--- a/README_en.md
+++ b/README_en.md
@@ -41,7 +41,7 @@ This project aggregates comprehensive information about the GaussDB open-source 
 | Middleware | Distributed Tasks | ElasticJob          | 3.1.0            | 505.2.0  | 506.0.0    | [Usage Guide](Elasticjob/3.1.0/README_en.md)        |
 | AI | Vector Search | LlamaIndex-GaussDB    | 0.1.0            | 505.2.0  |            | [Usage Guide](./LlamaIndex-GaussDB/0.1.0/README_en.md) |
 | AI | Vector Search | LangChain-GaussDB     | 0.1.0            | 505.2.0  |            | [Usage Guide](./LangChain-GaussDB/0.1.0/README_en.md) |
-| AI | Agent Memory | Mem0-GaussDB     | 2.0.4            | 505.2.0  | - | [Usage Guide](./Mem0-GaussDB/2.0.4/README_en.md) |
+| AI | Agent Memory | Mem0-GaussDB     | 2.0.4            | 507.0.0  | - | [Usage Guide](./Mem0-GaussDB/2.0.4/README_en.md) |
 
 * Use `select version()` to check your GaussDB version.  
 * Refer to [gaussdb-drivers](https://github.com/HuaweiCloudDeveloper/gaussdb-drivers) for driver details.  


### PR DESCRIPTION
## Summary
- update the GaussDB compatibility version displayed for Mem0-GaussDB, RAGFlow-GaussDB, and LangGraph-GaussDB from `505.2.0` to `507.0.0`
- keep all component versions, driver versions, and usage-guide links unchanged
- synchronize the existing English Mem0-GaussDB entry

## Validation
- `git diff --check`
- checked all existing target table rows and confirmed other version-matrix rows were not changed